### PR TITLE
Allow for cpanfile as well as Makefile.PL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ WriteMakefile(
 );
 ```
 
+Alternately, you may create a
+[cpanfile](http://search.cpan.org/~miyagawa/Module-CPANfile-1.0002/lib/cpanfile.pod)
+that lists dependencies instead:
+
+```
+requires 'Mojolicious', '2.0';
+```
+
 ## Step 3
 
 Create an executable file called Perloku which runs a server on the port

--- a/bin/compile
+++ b/bin/compile
@@ -22,7 +22,7 @@ export PERL5LIB="$VENDORED_PERL/lib/$PERL_VERSION:$VENDORED_PERL/lib/site_perl/$
 
 echo "Using Perl $PERL_VERSION" | indent
 
-if [ -f $BUILD_DIR/Makefile.PL ]; then
+if [ -f $BUILD_DIR/Makefile.PL ] || [ -f $BUILD_DIR/cpanfile ]; then
   echo "-----> Installing dependencies"
   VENDOR_DEPS="$BUILD_DIR/vendor/perl-deps"
   CACHE_DEPS="$CACHE_DIR/$PERL_VERSION/perl-deps"


### PR DESCRIPTION
This PR allows using a [cpanfile](http://search.cpan.org/~miyagawa/Module-CPANfile-1.0002/lib/cpanfile.pod) instead of Makefile.PL to declare dependencies. Since the buildpack installs with `cpanm --install-deps` anyway, the `cpanfile` works exactly the same (as would `Build.PL` or `META.json`...I could add support for those too if you're interested).
