### PR TITLE
Changed to using Procfile

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -36,3 +36,4 @@ if [ -f $BUILD_DIR/Makefile.PL ] || [ -f $BUILD_DIR/cpanfile ]; then
   echo "Dependencies installed" | indent
 fi
 
+mv "$BUILD_DIR/Perloku" "$BUILD_DIR/Procfile"

--- a/bin/release
+++ b/bin/release
@@ -7,6 +7,4 @@ cat << EOF
 config_vars:
   PATH: /app/vendor/perl/bin:/usr/bin:/bin
   PERL5OPT: -Mlocal::lib=/app/vendor/perl-deps
-default_process_types:
-  web: ./Perloku $PORT
 EOF


### PR DESCRIPTION
I think this resolves #2 

The Perloku file is still used in the detect script to verify that the perloku buildpack should be applied, but it is moved to Procfile in the $BUILD_DIR when it's done compiling.