### PR TITLE
Update to new Heroku procfile, update Perl to 5.26.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,15 @@ Deploy Perl applications in seconds.
 
 ## Step 1
 
-Write an app:
+Write an app (or `mojo generate lite_app`):
 
 ```perl
 #!/usr/bin/env perl
 use Mojolicious::Lite;
 
 get '/' => sub {
-  my $self = shift;
-  $self->render('index');
+  my $c = shift;
+  $c->render(template => 'index');
 };
 
 app->start;
@@ -22,7 +22,7 @@ __DATA__
 @@ index.html.ep
 % layout 'default';
 % title 'Welcome';
-Welcome to the Mojolicious real-time web framework!
+<h1>Welcome to the Mojolicious real-time web framework!</h1>
 
 @@ layouts/default.html.ep
 <!DOCTYPE html>
@@ -34,7 +34,7 @@ Welcome to the Mojolicious real-time web framework!
 
 ## Step 2
 
-Create a Makefile.PL with your dependencies:
+Create a Makefile.PL with your dependencies (or `mojo generate makefile`):
 
 ```perl
 use strict;
@@ -43,39 +43,34 @@ use warnings;
 use ExtUtils::MakeMaker;
 
 WriteMakefile(
-  NAME         => 'app.pl',
-  VERSION      => '1.0',
-  AUTHOR       => 'Magnus Holm <judofyr@gmail.com>',
-  EXE_FILES    => ['app.pl'],
-  PREREQ_PM    => {'Mojolicious' => '2.0'},
-  test         => {TESTS => 't/*.t'}
+  VERSION   => '0.01',
+  PREREQ_PM => {'Mojolicious' => '8.05'},
+  test      => {TESTS => 't/*.t'}
 );
 ```
 
 Alternately, you may create a
-[cpanfile](http://search.cpan.org/~miyagawa/Module-CPANfile-1.0002/lib/cpanfile.pod)
+[cpanfile](https://metacpan.org/pod/distribution/Module-CPANfile/lib/cpanfile.pod)
 that lists dependencies instead:
 
 ```
-requires 'Mojolicious', '2.0';
+requires 'Mojolicious', '8.05';
 ```
 
 ## Step 3
 
-Create an executable file called Perloku which runs a server on the port
+Create an executable file called Procfile which runs a server on the port
 given as an enviroment variable:
 
 ```sh
-#!/bin/sh
-./app.pl daemon --listen http://*:$PORT
+web: ./myapp.pl daemon --listen http://*:$PORT --mode production
 ```
 
 
 Test that you can start the server:
 
 ```sh
-chmod +x Perloku
-PORT=3000 ./Perloku
+export PORT=3000 && ./myapp.pl daemon --listen http://*:$PORT --mode production
 ```
 
 ## Step 4
@@ -85,10 +80,9 @@ Deploy:
 ```sh
 git init
 git add .
-git update-index --chmod=+x Perloku (only if using Windows)
-git update-index --chmod=+x app.pl (only if using Windows)
+git update-index --chmod=+x myapp.pl (only if using Windows)
 git commit -m "Initial version"
-heroku create -s cedar --buildpack http://github.com/judofyr/perloku.git
+heroku create -s cedar --buildpack https://github.com/judofyr/perloku.git
 git push heroku master
 ```
 
@@ -96,37 +90,53 @@ git push heroku master
 Watch:
 
 ```
-Counting objects: 5, done.
-Delta compression using up to 8 threads.
-Compressing objects: 100% (4/4), done.
-Writing objects: 100% (5/5), 808 bytes, done.
+Enumerating objects: 5, done.
+Counting objects: 100% (5/5), done.
+Delta compression using up to 8 threads
+Compressing objects: 100% (5/5), done.
+Writing objects: 100% (5/5), 767 bytes | 767.00 KiB/s, done.
 Total 5 (delta 0), reused 0 (delta 0)
-
------> Heroku receiving push
------> Fetching custom buildpack... done
------> Perloku app detected
------> Vendoring Perl
-       Using Perl 5.16.2
------> Installing dependencies
-       --> Working on /tmp/build_19tm6pb8ch1qa
-       Configuring /tmp/build_19tm6pb8ch1qa ... OK
-       ==> Found dependencies: Mojolicious
-       --> Working on Mojolicious
-       Fetching http://search.cpan.org/CPAN/authors/id/T/TE/TEMPIRE/Mojolicious-2.48.tar.gz ... OK
-       Configuring Mojolicious-2.48 ... OK
-       Building Mojolicious-2.48 ... OK
-       Successfully installed Mojolicious-2.48
-       <== Installed dependencies for /tmp/build_19tm6pb8ch1qa. Finishing.
-       1 distribution installed
-       Dependencies installed
------> Discovering process types
-       Procfile declares types   -> (none)
-       Default types for Perloku -> web
------> Compiled slug size is 12.4MB
------> Launching...gi done, v5
-       http://perloku-example.herokuapp.com deployed to Heroku
-
-To git@heroku.com:perloku-example.git
+remote: Compressing source files... done.
+remote: Building source:
+remote:
+remote: -----> Perloku app detected
+remote: -----> Vendoring Perl
+remote:        Using Perl 5.26.2
+remote: -----> Installing dependencies
+remote:        --> Working on /tmp/build_e78a53b852d3889ea231fc4062b0debb
+remote:        Configuring /tmp/build_e78a53b852d3889ea231fc4062b0debb ... OK
+remote:        ==> Found dependencies: Mojolicious
+remote:        --> Working on Mojolicious
+remote:        Fetching http://www.cpan.org/authors/id/S/SR/SRI/Mojolicious-8.05.tar.gz ... OK
+remote:        Configuring Mojolicious-8.05 ... OK
+remote:        ==> Found dependencies: List::Util, IO::Socket::IP
+remote:        --> Working on List::Util
+remote:        Fetching http://www.cpan.org/authors/id/P/PE/PEVANS/Scalar-List-Utils-1.50.tar.gz ... OK
+remote:        Configuring Scalar-List-Utils-1.50 ... OK
+remote:        Building Scalar-List-Utils-1.50 ... OK
+remote:        Successfully installed Scalar-List-Utils-1.50 (upgraded from 1.27)
+remote:        --> Working on IO::Socket::IP
+remote:        Fetching http://www.cpan.org/authors/id/P/PE/PEVANS/IO-Socket-IP-0.39.tar.gz ... OK
+remote:        Configuring IO-Socket-IP-0.39 ... OK
+remote:        Building IO-Socket-IP-0.39 ... OK
+remote:        Successfully installed IO-Socket-IP-0.39
+remote:        Building Mojolicious-8.05 ... OK
+remote:        Successfully installed Mojolicious-8.05
+remote:        <== Installed dependencies for /tmp/build_e78a53b852d3889ea231fc4062b0debb. Finishing.
+remote:        3 distributions installed
+remote:        Dependencies installed
+remote: -----> Discovering process types
+remote:        Procfile declares types     -> (none)
+remote:        Default types for buildpack -> web
+remote:
+remote: -----> Compressing...
+remote:        Done: 14.2M
+remote: -----> Launching...
+remote:        Released v4
+remote:        https://perloku-example.herokuapp.com/ deployed to Heroku
+remote:
+remote: Verifying deploy... done.
+To https://git.heroku.com/perloku-example.git
  * [new branch]      master -> master
 ```
 

--- a/bin/compile
+++ b/bin/compile
@@ -8,7 +8,7 @@ BUILD_DIR=$1
 CACHE_DIR=$2
 
 PERL_VERSION="5.26.2"
-PERL_PACKAGE="https://raw.githubusercontent.com/rage311/perloku/master/support/perl-$PERL_VERSION.tgz"
+PERL_PACKAGE="https://raw.githubusercontent.com/judofyr/perloku/master/support/perl-$PERL_VERSION.tgz"
 
 VENDORED_PERL="$BUILD_DIR/vendor/perl"
 
@@ -35,5 +35,3 @@ if [ -f $BUILD_DIR/Makefile.PL ] || [ -f $BUILD_DIR/cpanfile ]; then
 
   echo "Dependencies installed" | indent
 fi
-
-mv "$BUILD_DIR/Perloku" "$BUILD_DIR/Procfile"

--- a/bin/compile
+++ b/bin/compile
@@ -36,3 +36,4 @@ if [ -f $BUILD_DIR/Makefile.PL ] || [ -f $BUILD_DIR/cpanfile ]; then
   echo "Dependencies installed" | indent
 fi
 
+mv "$BUILD_DIR/Perloku" "$BUILD_DIR/Procfile"

--- a/bin/compile
+++ b/bin/compile
@@ -7,8 +7,8 @@ indent() {
 BUILD_DIR=$1
 CACHE_DIR=$2
 
-PERL_VERSION="5.18.1"
-PERL_PACKAGE="perloku.s3.amazonaws.com/perl-$PERL_VERSION.tgz"
+PERL_VERSION="5.26.2"
+PERL_PACKAGE="https://raw.githubusercontent.com/rage311/perloku/master/support/perl-$PERL_VERSION.tgz"
 
 VENDORED_PERL="$BUILD_DIR/vendor/perl"
 

--- a/bin/detect
+++ b/bin/detect
@@ -1,11 +1,5 @@
 #!/bin/sh
 
-if [ -x $1/Perloku ]; then
-  echo "Perloku"
-  exit 0
-else
-  exit 1
-fi
-
+# always exit 0 since perloku is opt-in anyway
 exit 0
 

--- a/bin/release
+++ b/bin/release
@@ -7,6 +7,4 @@ cat << EOF
 config_vars:
   PATH: /app/vendor/perl/bin:/usr/bin:/bin
   PERL5OPT: -Mlocal::lib=/app/vendor/perl-deps
-default_process_types:
-  web: ./Perloku $PORT
 EOF

--- a/support/build_perl
+++ b/support/build_perl
@@ -1,5 +1,5 @@
-#!/bin/sh
-PERL_VERSION="perl-5.18.1"
+#!/bin/bash
+PERL_VERSION="perl-5.26.2"
 PERLBREW_URL="http://install.perlbrew.pl"
 CPANM_URL="http://cpanmin.us"
 
@@ -8,15 +8,10 @@ PERLBREW_INSTALL_OPTIONS="-Duserelocatableinc -n -v"
 
 PERL_ROOT="$PERLBREW_ROOT/perls/$PERL_VERSION"
 
-vulcan build -v -p "$PERL_ROOT" -c "
-echo '
-export PERLBREW_ROOT=$PERLBREW_ROOT
-curl -kL $PERLBREW_URL | bash
-source $PERLBREW_ROOT/etc/bashrc
-perlbrew init
-perlbrew install $PERL_VERSION $PERLBREW_INSTALL_OPTIONS
-perlbrew use $PERL_VERSION
-curl -L $CPANM_URL | perl - --self-upgrade
-cpanm local::lib
-' | bash"
-
+curl -kL $PERLBREW_URL | bash \
+  && source $PERLBREW_ROOT/etc/bashrc \
+  && perlbrew init \
+  && perlbrew install $PERL_VERSION $PERLBREW_INSTALL_OPTIONS \
+  && perlbrew use $PERL_VERSION \
+  && curl -L $CPANM_URL | perl - --self-upgrade \
+  && cpanm local::lib


### PR DESCRIPTION
Trying this again now that I have more knowledge and experience with Heroku.

I've updated the compile script to reflect the new Perl version, tarball location, and added the `mv` to move the Perloku file to Heroku's new-style "Procfile".  I've updated the `build_perl` script to be able to be run inside Heroku's Build Docker containers, since Vulcan is deprecated.  That's how I compiled 5.26.1 and 5.26.2, so I've confirmed that it works.

I've been using my forked Perloku repo for several successfully-deployed Perl/Mojolicious projects, so I have confidence in saying that these changes can help push this project forward.